### PR TITLE
Fix: `INVALID` userError handling 

### DIFF
--- a/src/helpers/request.ts
+++ b/src/helpers/request.ts
@@ -42,7 +42,7 @@ export default async function request(country: EuropeanMemberState, number: stri
 
 	const userError = response?.userError;
 
-	if (userError && !['VALID', 'INVALID_INPUT'].includes(userError)) {
+	if (userError && !['VALID', 'INVALID', 'INVALID_INPUT'].includes(userError)) {
 		throw new Error(userError);
 	}
 

--- a/test/vies-checker.test.ts
+++ b/test/vies-checker.test.ts
@@ -6,7 +6,6 @@ test('Check valid VIES', async () => {
 });
 
 test('Check valid country code + invalid number VIES', async () => {
-	// @ts-ignore
 	const result = await isValid('ES', 'ABC123456');
 	expect(result).toBe(false);
 });

--- a/test/vies-checker.test.ts
+++ b/test/vies-checker.test.ts
@@ -5,8 +5,14 @@ test('Check valid VIES', async () => {
 	expect(result).toBe(true);
 });
 
-test('Check invalid VIES', async () => {
+test('Check valid country code + invalid number VIES', async () => {
 	// @ts-ignore
-	const result = await isValid('ML', 'ABC123456');
+	const result = await isValid('ES', 'ABC123456');
+	expect(result).toBe(false);
+});
+
+test('Check invalid country code VIES', async () => {
+	// @ts-ignore
+	const result = await isValid('ZZ', 'ABC123456');
 	expect(result).toBe(false);
 });


### PR DESCRIPTION
Hi,

I noticed today, that the VIES service actually differentiates between `INVALID` and `INVALID_INPUT` userError messages:

* `INVALID` is returned, when you provide a valid country code, but the number is invalid
* `INVALID_INPUT` is returned, when the country code you provide is not valid

in both cases, it should be fine to say that the VAT Check returned "false" – however in the current version, `vies-checker` will currently throw an error, when you run e.g. `await isValid('ES', 'ABC123456')` (valid country + invalid vat no -> which would return `INVALID` as userError value).

To fix this, I've adapted the list of "handled" userErrors accordingly.

I also updated the tests accordingly as well, to now test all 3 cases.

Let me know, if there are any questions.

Kind regards,
