### PR TITLE
Docs: fix tiny typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ try {
 ```
 
 ### Errors
-These are the errors that might ocurr. Use a try/catch to handle them properly.
+These are the errors that might occur. Use a try/catch to handle them properly.
 
 | Error name | Description |
 |---|---|


### PR DESCRIPTION
Hi,

just a tiny typo in the README -> `ocurr` vs `occur`